### PR TITLE
FIX #27: Python SyntaxWarnings in python-scripts.

### DIFF
--- a/Generator/CppHeaderParser.py
+++ b/Generator/CppHeaderParser.py
@@ -222,7 +222,7 @@ def extract_namespace_namestack(nameStack):
     nstack = nameStack[1:]
     namespaceSeparator = 2
     for i in range(len(nstack)):
-        if namespaceSeparator is 2:
+        if namespaceSeparator == 2:
             ns += nstack[i]
             if ns is not nstack[i] and i is not len(nstack) - 1:
                 ns += "::"

--- a/Generator/FSeamerFile.py
+++ b/Generator/FSeamerFile.py
@@ -423,7 +423,7 @@ class FSeamerFile:
     def _clearDataStructureData(content, className):
         sb, sm, se = content.partition(CLASS_START_FMT.format(className))
         eb, em, ee = content.partition(CLASS_END_FMT.format(className))
-        return sb + ee if sm is not "" and em is not "" else content
+        return sb + ee if sm != "" and em != "" else content
 
     @staticmethod
     def _clearSpecialization(content, className):


### PR DESCRIPTION
Fixes issue/bug #27 Python SyntaxWarnings in FSeam python-scripts.
Verified with how-to-reproduce procedure in issue #27.