### PR TITLE
FIX #26: FSeam installed cmake-package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ include(CMakePackageConfigHelpers)
 install(TARGETS FSeam FSeam-static
         EXPORT ${PROJECT_NAME}-targets)
 
-install(FILES ${FSEAM_HEADERS} DESTINATION share/include/FSeam)
+install(FILES ${FSEAM_HEADERS} DESTINATION include/FSeam)
 install(PROGRAMS ${FSEAM_GENERATOR_PYTH} DESTINATION share/bin)
 install(PROGRAMS ${FSEAM_GENERATOR_PYTH} DESTINATION bin)
 


### PR DESCRIPTION
FIXES: PROBLEM 1 (only)
Use "INSTALL_ROOT/include" instead of "INSTALL_ROOT/share/include"
for install header files.